### PR TITLE
fix: prevent command injection in technique execution and malware retrieval

### DIFF
--- a/Web/app.py
+++ b/Web/app.py
@@ -142,6 +142,8 @@ def api_mitre_attack_execution():
     technique_id = request.args.get('technique_id')
     if not technique_id:
         return jsonify({"msg": "technique_id is required"}), 400
+    if not re.match(r'^T\d{4}(\.\d{3})?$', technique_id):
+        return jsonify({"msg": "Invalid technique_id format"}), 400
 
   
     powershell_command = f"\"& {{Import-Module 'C:\\\\AtomicRedTeam\\\\invoke-atomicredteam\\\\Invoke-AtomicRedTeam.psd1' -Force; Invoke-AtomicTest {technique_id}}}\""
@@ -169,10 +171,10 @@ def malware_retrieval():
     if not malware_family:
         return jsonify({"error": "Missing malwareFamily parameter"}), 400
 
-    malware_family = malware_family.replace('"', '\"').replace('`', '\`').replace('$', '\$')
+    # Use shlex.quote for proper shell escaping
 
     # Executes the Python script and returns the PID
-    command = f"sudo python3 /var/www/html/scripts/malwareretrieval.py '{malware_family}' > /dev/null 2>&1 & echo $!"
+    command = f"sudo python3 /var/www/html/scripts/malwareretrieval.py {shlex.quote(malware_family)} > /dev/null 2>&1 & echo $!"
     process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
     pid = process.stdout.read().decode('utf-8').strip()
 


### PR DESCRIPTION
## Summary

Prevent command injection in technique execution and malware retrieval endpoints by validating user input.

## Problem

### 1. Technique ID injection (line ~142-147)
The `technique_id` parameter from `request.args.get('technique_id')` is directly interpolated into a PowerShell command:

```python
technique_id = request.args.get('technique_id')
powershell_command = f'"& {{... Invoke-AtomicTest {technique_id}}}"'
subprocess.run(['VBoxManage', ..., powershell_command], ...)
```

An attacker can inject arbitrary PowerShell commands: `?technique_id=T1059; Remove-Item -Recurse C:\`

### 2. Malware family injection (line ~168-176)
The `malwareFamily` from `request.json` is passed to `subprocess.Popen` with `shell=True` after incomplete sanitization:

```python
malware_family = malware_family.replace('"', '\"')...  # doesn't escape single quotes
command = f"sudo python3 ... '{malware_family}' > /dev/null 2>&1 & echo $!"
subprocess.Popen(command, shell=True, ...)
```

A `malware_family` containing `'; rm -rf / #` breaks out of the single quotes.

## Fix

1. **technique_id**: Validate against ATT&CK format regex `^T\d{4}(\.\d{3})?$`
2. **malware_family**: Replace incomplete manual escaping with `shlex.quote()` for proper shell escaping

## Impact

- **Type**: Command Injection (CWE-78)
- **Affected endpoints**: Technique execution, malware retrieval
- **Risk**: Arbitrary command execution on the host and sandbox VM
- **OWASP**: A03:2021 — Injection